### PR TITLE
Fix filtering by boolean

### DIFF
--- a/lib/types/json_api.rb
+++ b/lib/types/json_api.rb
@@ -12,7 +12,7 @@ module Types
         {
           string: ::Types::String,
           number: ::Types::Form::Int | ::Types::Form::Decimal,
-          boolean: ::Types::Form::Nil,
+          boolean: ::Types::Form::True | ::Types::Form::False | ::Types::Form::Nil,
           date: ::Types::Form::Date | ::Types::Form::Int
         }[column]
       end

--- a/spec/lib/types/json_api_spec.rb
+++ b/spec/lib/types/json_api_spec.rb
@@ -31,6 +31,20 @@ module Types
       end
     end
 
+    context 'when column type equal to boolean true value' do
+      let(:column) { :boolean }
+      let(:value) { true }
+
+      include_examples 'checks value type'
+    end
+
+    context 'when column type equal to boolean false value' do
+      let(:column) { :boolean }
+      let(:value) { false }
+
+      include_examples 'checks value type'
+    end
+
     context 'when column type equal to boolean' do
       let(:column) { :boolean }
       let(:value) { '' }


### PR DESCRIPTION
### Description

Currently, we can not filter records by following formats:
`?filter[some_boolean_field_name-true]=1`
`?filter[some_boolean_field_name-true]=0` 
`?filter[some_boolean_field_name-false]=1`
`?filter[some_boolean_field_name-false]=0`

I had always get BadRequest in such cases.
Added true/false as valid types.

### Before submitting the merge request make sure the following are checked

- [x] Followed the style guidelines of this project
- [x] Performed a self-review of own code
- [x] Wrote the tests that prove that fix is effective/that feature works
