### PR TITLE
PEO-1282 | add predicates `in` and `not_in`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Project wiki: https://github.com/rubygarage/boilerplate/wiki
 
 | Operation | Description | HTTP request example |
 | --- | --- | --- |
-| ```Api::V1::Lib::Operation::Filtering``` | Provides JSON API filtering with ```all_filters``` as default matcher | ```GET /users?filter[email-eq]=user@email.com&filter[name-cont]=son&match=any_filters``` |
-| ```Api::V1::Lib::Operation::Sorting``` | Provides JSON API sorting | ```GET /users?sort=name,-age``` |
+| ```Api::V1::Lib::Operation::Filtering``` | Sets JSON API filtering with ```all_filters``` as default matcher | ```GET /users?filter[email-eq]=user@email.com&filter[name-cont]=son&match=any_filters``` |
+| ```Api::V1::Lib::Operation::PerformFiltering``` | Provides JSON API filtering with ```ctx[:filter_options]``` options | ```GET /users?filter[email-eq]=user@email.com&filter[name-cont]=son&match=any_filters``` |
+| ```Api::V1::Lib::Operation::Sorting``` | Sets JSON API sorting | ```GET /users?sort=name,-age``` |
+| ```Api::V1::Lib::Operation::PerformOrdering``` | Provides JSON API sorting | ```GET /users?sort=name,-age``` |
 | ```Api::V1::Lib::Operation::Inclusion``` | Provides JSON API inclusion of related resources. Dot-separated relationship path supporting not implemented at this time | ```GET /users?include=team,organization``` |
 | ```Api::V1::Lib::Operation::Pagination``` | Provides JSON API pagination with offset strategy. Accepts ```AciveRelation``` or ```Array``` as collection. By default returns 25 items per page | ```GET /users?page[number]=1&page[size]=1``` |
 

--- a/app/concepts/api/v1/lib/operation/perform_filtering.rb
+++ b/app/concepts/api/v1/lib/operation/perform_filtering.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api::V1::Lib::Operation
+  class PerformFiltering < ApplicationOperation
+    step :filter_options_passed?, Output(:failure) => End(:success)
+    pass :build_filter_query
+    pass :filter_relation
+
+    def filter_options_passed?(ctx, **)
+      ctx[:filter_options]
+    end
+
+    def build_filter_query(ctx, filter_options:, **)
+      ctx[:filter_query] = filter_options.map do |option|
+        value = option[:value]
+        value = value.include?(',') ? value.split(',') : value
+
+        {
+          "#{option[:column]}_#{option[:predicate]}": value
+        }
+      end.inject(:merge)
+    end
+
+    def filter_relation(ctx, filter_query:, relation:, **)
+      ctx[:relation] = relation.ransack(filter_query).result
+    end
+  end
+end

--- a/app/concepts/api/v1/lib/operation/perform_ordering.rb
+++ b/app/concepts/api/v1/lib/operation/perform_ordering.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api::V1::Lib::Operation
+  class PerformOrdering < ApplicationOperation
+    step :order_options_passed?, Output(:failure) => End(:success)
+    pass :order_relation
+
+    def order_options_passed?(ctx, **)
+      ctx[:order_options]
+    end
+
+    def order_relation(ctx, order_options:, relation:, **)
+      ctx[:relation] = relation.reorder(order_options)
+    end
+  end
+end

--- a/config/initializers/json_api/filtering.rb
+++ b/config/initializers/json_api/filtering.rb
@@ -10,6 +10,8 @@ module JsonApi
     OPERATORS = [Operators::MATCH_ALL, Operators::MATCH_ANY].freeze
 
     module Predicates
+      IN = 'in'
+      NOT_IN = 'not_in'
       EQUAL = 'eq'
       EQUAL_RELATIVE = 'eq_rel'
       NOT_EQUAL = 'not_eq'
@@ -29,12 +31,16 @@ module JsonApi
 
     PREDICATES = {
       string: [
+        Predicates::IN,
+        Predicates::NOT_IN,
         Predicates::EQUAL,
         Predicates::NOT_EQUAL,
         Predicates::CONTAINS,
         Predicates::NOT_CONTAINS
       ].to_set,
       number: [
+        Predicates::IN,
+        Predicates::NOT_IN,
         Predicates::EQUAL,
         Predicates::NOT_EQUAL,
         Predicates::GREATER_THAN,

--- a/lib/types/json_api.rb
+++ b/lib/types/json_api.rb
@@ -10,8 +10,11 @@ module Types
     module TypeByColumn
       def self.call(column)
         {
-          string: ::Types::String,
-          number: ::Types::Form::Int | ::Types::Form::Decimal,
+          string: ::Types::String | ::Types::Array.of(::Types::String),
+          number: ::Types::Form::Int |
+            ::Types::Form::Decimal |
+            ::Types::Array.of(::Types::Int) |
+            ::Types::Array.of(::Types::Decimal),
           boolean: ::Types::Form::True | ::Types::Form::False | ::Types::Form::Nil,
           date: ::Types::Form::Date | ::Types::Form::Int
         }[column]

--- a/spec/concepts/api/v1/lib/operation/perform_filtering_spec.rb
+++ b/spec/concepts/api/v1/lib/operation/perform_filtering_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::V1::Lib::Operation::PerformFiltering do
+  subject(:operation) { described_class.call(params) }
+
+  let(:params) { { filter_options: filter_options, relation: relation } }
+  let(:relation) { User.all }
+
+  describe 'Success' do
+    context 'when filter options not passed' do
+      let(:filter_options) { nil }
+
+      it 'return success result' do
+        expect(operation[:relation]).to eq(relation)
+        expect(operation).to be_success
+      end
+    end
+
+    context 'when filter options is passed' do
+      let(:filter_options) { [{ column: 'name', predicate: predicate, value: search_value }] }
+      let(:search_value) { search_name }
+      let(:search_name) { 'Uniqueness_name' }
+      let!(:user) { create(:user, name: search_name) }
+
+      before { create_list(:user, 2) }
+
+      context 'when pass several filter values' do
+        let(:search_value) { [search_name, search_name_2].join(',') }
+        let(:search_name_2) { 'user2' }
+        let(:predicate) { 'in' }
+        let(:second_user) { create(:user, name: search_name_2) }
+
+        it 'returns users that contains search value' do
+          expect(operation[:relation]).to include(user, second_user)
+          expect(operation).to be_success
+        end
+      end
+
+      context 'with contain predicate' do
+        let(:predicate) { 'cont' }
+
+        it 'returns users that contains search value' do
+          expect(operation[:relation]).to eq([user])
+          expect(operation).to be_success
+        end
+      end
+
+      context 'with not_in predicate' do
+        let(:predicate) { 'not_in' }
+
+        it 'returns users that contains search value' do
+          expect(operation[:relation]).not_to include(user)
+          expect(operation).to be_success
+        end
+      end
+    end
+  end
+end

--- a/spec/concepts/api/v1/lib/operation/perform_ordering_spec.rb
+++ b/spec/concepts/api/v1/lib/operation/perform_ordering_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::V1::Lib::Operation::PerformOrdering do
+  subject(:operation) { described_class.call(params) }
+
+  let(:params) { { order_options: order_options, relation: relation } }
+  let(:relation) { User.all }
+
+  describe 'Success' do
+    context 'when ordering options not passed' do
+      let(:order_options) { nil }
+
+      it 'return success result' do
+        expect(operation[:relation]).to eq(relation)
+        expect(operation).to be_success
+      end
+    end
+
+    context 'when order options is passed' do
+      let(:order_options) { { name: :desc } }
+
+      before { create_list(:user, 3) }
+
+      it 'returns ordered relation' do
+        expect(operation[:relation].to_a).to eq(User.all.order(name: :desc).to_a)
+        expect(operation).to be_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
[PEO-1282](https://garage.atlassian.net/browse/PEO-1282)

### Description

Added PerformFiltering operation
Added PerformOrdering operation
Added predicates `in` and `not_in`

Replace this text with a summary of the changes in your merge request.

### Before submitting the merge request make sure the following are checked

- [x] Followed the style guidelines of this project
- [x] Performed a self-review of own code
- [x] Wrote the tests that prove that fix is effective/that feature works
