### PR TITLE
ISSUE-271 | Downgrade json_matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ end
 group :test do
   gem 'capybara', '~> 3.33'
   gem 'dox', '~> 1.2'
-  gem 'json_matchers', '~> 0.11.1', require: 'json_matchers/rspec'
+  gem 'json_matchers', '~> 0.10.0', require: 'json_matchers/rspec'
   gem 'mock_redis', '~> 0.22.0'
   gem 'rails-controller-testing', '~> 1.0'
   gem 'rspec-sidekiq', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.3.1)
-    json_matchers (0.11.1)
+    json_matchers (0.10.0)
       json_schema
     json_schema (0.20.9)
     jsonapi-serializer (2.1.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   fasterer (~> 0.8.3)
   ffaker (~> 2.17)
   i18n-tasks (~> 0.9.31)
-  json_matchers (~> 0.11.1)
+  json_matchers (~> 0.10.0)
   jsonapi-serializer (~> 2.1)
   jwt_sessions (~> 2.5)
   lefthook (~> 0.7.2)


### PR DESCRIPTION
[ISSUE-271](https://github.com/rubygarage/boilerplate/issues/271)

### Description

- Downgrade json_matchers from `0.11.1` to `0.10.0`

### Before submitting the merge request make sure the following are checked

- [x] Followed the style guidelines of this project
