### PR TITLE
[ISSUE-263] Added ability to render errors for `gone` and `forbidden`

### DIFF
--- a/app/controllers/concerns/default_endpoint.rb
+++ b/app/controllers/concerns/default_endpoint.rb
@@ -7,8 +7,8 @@ module DefaultEndpoint
       match.destroyed    { head(:no_content) }
       match.unauthorized { |result| render_head_or_errors(result, :unauthorized) }
       match.not_found    { |result| render_head_or_errors(result, :not_found) }
-      match.forbidden    { head(:forbidden) }
-      match.gone         { head(:gone) }
+      match.forbidden    { |result| render_head_or_errors(result, :forbidden) }
+      match.gone         { |result| render_head_or_errors(result, :gone) }
       match.accepted     { head(:accepted) }
       match.invalid      { |result| render_errors(result, :unprocessable_entity) }
       match.success      { |result| success_response(result) }

--- a/spec/concepts/api/v1/lib/operation/perform_filtering_spec.rb
+++ b/spec/concepts/api/v1/lib/operation/perform_filtering_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe Api::V1::Lib::Operation::PerformFiltering do
         end
       end
 
+      context 'when pass datetime as value' do
+        let(:search_value) { user.created_at.to_json }
+        let(:filter_column) { 'created_at' }
+        let(:predicate) { 'eq' }
+
+        it 'returns users that contains search value' do
+          expect(operation[:relation]).to include(user)
+          expect(operation).to be_success
+        end
+      end
+
       context 'when pass array as value' do
         let(:search_value) { [user.id] }
         let(:filter_column) { 'id' }

--- a/spec/controllers/concerns/default_endpoint_spec.rb
+++ b/spec/controllers/concerns/default_endpoint_spec.rb
@@ -89,16 +89,16 @@ RSpec.describe DefaultEndpoint do
 
     context 'when forbidden matcher' do
       let(:matcher_case) { { forbidden: true } }
-      let(:expected_method) { :head }
-      let(:args) { [:forbidden] }
+      let(:expected_method) { :render_head_or_errors }
+      let(:args) { [result, :forbidden] }
 
       it_behaves_like('calls specific method')
     end
 
     context 'when gone matcher' do
       let(:matcher_case) { { gone: true } }
-      let(:expected_method) { :head }
-      let(:args) { [:gone] }
+      let(:expected_method) { :render_head_or_errors }
+      let(:args) { [result, :gone] }
 
       it_behaves_like('calls specific method')
     end


### PR DESCRIPTION
[263](https://github.com/rubygarage/boilerplate/issues/263)

### Description

Replaced call methods for 422, 420 statuses

### Before submitting the merge request make sure the following are checked

- [x] Followed the style guidelines of this project
- [x] Performed a self-review of own code
- [x] Wrote the tests that prove that fix is effective/that feature works
